### PR TITLE
Fix bug: nvim_echo must not be called in a lua loop callback

### DIFF
--- a/lua/pomodoro/log.lua
+++ b/lua/pomodoro/log.lua
@@ -3,10 +3,15 @@ local log = {}
 local p = "[pomodoro.nvim] "
 
 function log.info(txt)
-    vim.notify(p .. txt)
+    vim.schedule(function()
+        vim.notify(p .. txt)
+    end)
 end
 
 function log.error(txt)
-    vim.notify(p .. txt)
+    vim.schedule(function()
+        vim.notify(p .. txt)
+    end)
 end
+
 return log


### PR DESCRIPTION
Fixes #6

Fix the 'nvim_echo must not be called in a lua loop callback' error when a break ends.

* **lua/pomodoro/log.lua**
  - Use `vim.schedule` to call `vim.notify` in the `info` function.
  - Use `vim.schedule` to call `vim.notify` in the `error` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/QuentinGruber/pomodoro.nvim/issues/6?shareId=5f53be14-2e36-4128-9964-66a848f90665).