### PR TITLE
Added support to defining time for start and break timers

### DIFF
--- a/lua/pomodoro/pomodoro.lua
+++ b/lua/pomodoro/pomodoro.lua
@@ -111,6 +111,7 @@ function pomodoro.isInLongBreak()
 end
 
 function pomodoro.startBreak(time)
+    assert(type(time) == "number", "Expected a number value")
     local break_duration = time * MIN_IN_MS or pomodoro.break_duration
     pomodoro.phase = Phases.BREAK
     pomodoro.break_count = pomodoro.break_count + 1
@@ -130,6 +131,7 @@ function pomodoro.endBreak()
 end
 
 function pomodoro.start(time)
+    assert(type(time) == "number", "Expected a number value")
     local work_duration = time * MIN_IN_MS or pomodoro.work_duration
     info("Work session of " .. work_duration / MIN_IN_MS .. "m started!")
     pomodoro.phase = Phases.RUNNING
@@ -156,13 +158,15 @@ function pomodoro.stop()
 end
 
 function pomodoro.registerCmds()
-    vim.api.nvim_create_user_command(
-        "PomodoroForceBreak",
-        pomodoro.startBreak,
-        {}
-    )
+    vim.api.nvim_create_user_command("PomodoroForceBreak", function(opts)
+        local break_duration = tonumber(opts.args) or pomodoro.break_duration
+        pomodoro.startBreak(break_duration) -- or some default value
+    end, { nargs = "*" })
     vim.api.nvim_create_user_command("PomodoroSkipBreak", pomodoro.endBreak, {})
-    vim.api.nvim_create_user_command("PomodoroStart", pomodoro.start, {})
+    vim.api.nvim_create_user_command("PomodoroStart", function(opts)
+        local work_duration = tonumber(opts.args) or pomodoro.work_duration
+        pomodoro.start(work_duration) -- or some default value
+    end, { nargs = "*" })
     vim.api.nvim_create_user_command("PomodoroStop", pomodoro.stop, {})
     vim.api.nvim_create_user_command(
         "PomodoroDelayBreak",

--- a/lua/pomodoro/pomodoro.lua
+++ b/lua/pomodoro/pomodoro.lua
@@ -111,8 +111,7 @@ function pomodoro.isInLongBreak()
 end
 
 function pomodoro.startBreak(time)
-    assert(type(time) == "number", "Expected a number value")
-    local break_duration = time * MIN_IN_MS or pomodoro.break_duration
+    local break_duration = tonumber(time) * MIN_IN_MS or pomodoro.break_duration
     pomodoro.phase = Phases.BREAK
     pomodoro.break_count = pomodoro.break_count + 1
     if pomodoro.isInLongBreak() then
@@ -131,8 +130,7 @@ function pomodoro.endBreak()
 end
 
 function pomodoro.start(time)
-    assert(type(time) == "number", "Expected a number value")
-    local work_duration = time * MIN_IN_MS or pomodoro.work_duration
+    local work_duration = tonumber(time) * MIN_IN_MS or pomodoro.work_duration
     info("Work session of " .. work_duration / MIN_IN_MS .. "m started!")
     pomodoro.phase = Phases.RUNNING
     pomodoro.startTimer(work_duration, pomodoro.startBreak)

--- a/lua/pomodoro/pomodoro.lua
+++ b/lua/pomodoro/pomodoro.lua
@@ -110,14 +110,12 @@ function pomodoro.isInLongBreak()
         and pomodoro.phase == Phases.BREAK
 end
 
-function pomodoro.startBreak()
+function pomodoro.startBreak(time)
+    local break_duration = time * MIN_IN_MS or pomodoro.break_duration
     pomodoro.phase = Phases.BREAK
     pomodoro.break_count = pomodoro.break_count + 1
-    local break_duration
     if pomodoro.isInLongBreak() then
         break_duration = pomodoro.long_break_duration
-    else
-        break_duration = pomodoro.break_duration
     end
 
     info("Break of " .. break_duration / MIN_IN_MS .. "m started!")
@@ -131,12 +129,11 @@ function pomodoro.endBreak()
     pomodoro.start()
 end
 
-function pomodoro.start()
-    info(
-        "Work session of " .. pomodoro.work_duration / MIN_IN_MS .. "m started!"
-    )
+function pomodoro.start(time)
+    local work_duration = time * MIN_IN_MS or pomodoro.work_duration
+    info("Work session of " .. work_duration / MIN_IN_MS .. "m started!")
     pomodoro.phase = Phases.RUNNING
-    pomodoro.startTimer(pomodoro.work_duration, pomodoro.startBreak)
+    pomodoro.startTimer(work_duration, pomodoro.startBreak)
 end
 
 function pomodoro.delayBreak()


### PR DESCRIPTION
I wanted to add more timers since I need a longer work/break sessions sometimes.

Instead of having to always change the opts, I've added a option on the start and startBreak timers to allow for args.

    pomodoro.start(50)
    pomodoro.startBreak(10)

You can also define the time on the commands "PomodoroStart" and "PomodoroForceBreak"

    PomodoroStart 50
    PomodoroForceBreak 10

If no args are provided, it'll use the default ones (pomodoro.work_duration and pomodoro.break_duration) for both the functions and commands